### PR TITLE
Add fix for corrupted pom files

### DIFF
--- a/src/main/java/io/pivotal/cfapp/util/TgzUtil.java
+++ b/src/main/java/io/pivotal/cfapp/util/TgzUtil.java
@@ -86,7 +86,7 @@ public class TgzUtil {
         );
         return inputStreamMono.flatMapMany(is -> extractFileContent(is, filename))
                 .collectList()
-                .map(list -> String.join(" ", list));
+                .map(list -> String.join("", list));
     }
 
     private static Flux<String> extractFileContent(InputStream is, String filename) {


### PR DESCRIPTION
Every 1024 bytes an extra space was getting erroneously added causing pom files to be corrupt.