### PR TITLE
update legacy policy to notify org developers

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -56,7 +56,8 @@ See additional property requirements in this sample Github [repository](https://
 
 ### Legacy Policies
 
-Legacy policies are useful when you want to search for and report on applications deployed to a legacy stack (e.g., windows2012R2, cflinuxfs2) or service offering (e.g., using a product slug name like p-config-server, p-service-registry, p-mysql), notifying both the operator and for each application the author and/or his/her space compadres.
+Legacy policies are useful when you want to search for and report on applications deployed to a legacy stack (e.g., windows2012R2, cflinuxfs2) or service offering (e.g., using a product slug name like p-config-server, p-service-registry, p-mysql), notifying both the operator and for each application, users with the [space developer](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/roles.html#user-roles-2) role.
+
 
 As mentioned previously the policy file must adhere to a naming convention
 

--- a/src/main/java/org/cftoolsuite/cfapp/task/LegacyWorkloadReportingTask.java
+++ b/src/main/java/org/cftoolsuite/cfapp/task/LegacyWorkloadReportingTask.java
@@ -119,7 +119,7 @@ public class LegacyWorkloadReportingTask implements PolicyExecutorTask {
             // For each Space in Set<Space>, obtain SpaceUsers#getUsers()
             .concatMap(space -> spaceUsersService.findByOrganizationAndSpace(space.getOrganizationName(), space.getSpaceName()))
             // then pair with matching space(s) that contain applications and service instances
-            .concatMap(spaceUser -> Flux.fromIterable(spaceUser.getUsers()))
+            .concatMap(spaceUser -> Flux.fromIterable(spaceUser.getDevelopers()))
             .distinct()
             // filter out account names that are not email addresses
             .filter(EmailValidator::isValid)


### PR DESCRIPTION
There are sometimes hundreds of users listed as org auditors, and all of them don't do any development. The legacy policy helps us to aim to communicate to developers to migrate from legacy cflinuxfs3, and often time the hundreds of org auditors receive the notification are confused with the notifications. We'd like to focus on org developers exclusively on this notification.
